### PR TITLE
updates to deal with recent (Jan2015) webrtc source tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 WebRTC native C++ to browser PeerConnection example
 ===============================================
 
-This repository houses the code referenced by http://sourcey.com/webrtc-native-to-browser-video-streaming-example/
+This is a fork of the original code from https://github.com/auscaster.
+Modified to build and run with webrtc as of Jan 2015.
+Tested with Firefox (35.0) and Chrome (Version 39.0.2171.99).
+On Firefox I was successful accessing the native-to-browser-test.html
+page whether it was as a local file or through a server.
+On Chrome I found that the video only worked when I accessed
+the page through a server.
 
-Check out the blog post for usage instructions. Enjoy :)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 WebRTC native C++ to browser PeerConnection example
 ===============================================
 
-This is a fork of the original code from https://github.com/auscaster.
+This is a fork of the original code from https://github.com/auscaster/webrtc-native-to-browser-peerconnection-example.
 Modified to build and run with webrtc as of Jan 2015.
 Tested with Firefox (35.0) and Chrome (Version 39.0.2171.99).
 On Firefox I was successful accessing the native-to-browser-test.html

--- a/native-to-browser-test.html
+++ b/native-to-browser-test.html
@@ -1,6 +1,7 @@
 <html>
 <head>
 <title>PeerConnection server test page</title>
+</head>
 <script>
     var request = null;
     var hangingGet = null;
@@ -60,14 +61,25 @@
       remoteVideoElement.src = URL.createObjectURL(event.stream);
       remoteVideoElement.play();
     }
+
+    function sld_success_cb() {
+    }
+
+    function sld_failure_cb() {
+      console.log("setLocalDescription failed");
+    }
+
+    function aic_success_cb() {
+    }
+
+    function aic_failure_cb() {
+      console.log("addIceCandidate failed");
+    }
+
     
     function handlePeerMessage(peer_id, data) {
         ++messageCounter;
-        var str = "Message from '" + otherPeers[peer_id] + "'&nbsp;";
-        str += "<span id='toggle_" + messageCounter + "' onclick='toggleMe(this);' ";
-        str += "style='cursor: pointer'>+</span><br>";
-        str += "<blockquote id='msg_" + messageCounter + "' style='display:none'>";
-        str += data + "</blockquote>";
+        var str = "Message from '" + otherPeers[peer_id] + ":" + data;
         trace(str);
         
         var dataJson = JSON.parse(data);
@@ -77,7 +89,7 @@
             pc.setRemoteDescription(new RTCSessionDescription(dataJson), onRemoteSdpSucces, onRemoteSdpError);              
             pc.createAnswer(function(sessionDescription) {
                 console.log("Create answer:", sessionDescription);
-                pc.setLocalDescription(sessionDescription);
+                pc.setLocalDescription(sessionDescription,sld_success_cb,sld_failure_cb);
                 var data = JSON.stringify(sessionDescription);
                 sendToPeer(peer_id, data);
             }, function(error) { // error
@@ -87,7 +99,7 @@
         else {
             console.log("Adding ICE candiate ", dataJson);
             var candidate = new RTCIceCandidate({sdpMLineIndex: dataJson.sdpMLineIndex, candidate: dataJson.candidate});
-            pc.addIceCandidate(candidate);
+            pc.addIceCandidate(candidate, aic_success_cb, aic_failure_cb);
         }
     }    
     
@@ -190,6 +202,9 @@
           trace("error: " + e.description);
       }
     }
+
+    function dummy() {
+    }
     
     function sendToPeer(peer_id, data) {
       try {
@@ -203,13 +218,10 @@
               return;
           }
           var r = new XMLHttpRequest();
-          r.open("POST", server + "/message?peer_id=" + myId + "&to=" + peer_id, false);
+          r.onreadystatechange = dummy
+          r.open("POST", server + "/message?peer_id=" + myId + "&to=" + peer_id, true);
           r.setRequestHeader("Content-Type", "text/plain");
           r.send(data);
-          console.log(peer_id," Send ", data);
-          var dataJson = JSON.parse(data);
-          console.log(peer_id," send ", data);
-          r = null;
       } catch (e) {
           trace("send to peer error: " + e.description);
       }
@@ -224,7 +236,6 @@
         } else {
             document.getElementById("connect").disabled = true;
             document.getElementById("disconnect").disabled = false;
-            //document.getElementById("send").disabled = false;
             signIn();
         }
     }
@@ -250,7 +261,6 @@
       
         document.getElementById("connect").disabled = false;
         document.getElementById("disconnect").disabled = true;
-        document.getElementById("send").disabled = true;
     }
     
     window.onbeforeunload = disconnect;
@@ -297,14 +307,13 @@
         console.log('onRemoteSdpSucces');
     } 
 </script>
-</head>
 <body>
     <div id="container">
         <div id="remote">
             <video id="remote-video" width="50%" height="50%"></video>
         </div>
     </div>
-    Server: <input type="text" id="server" value="http://localhost:8888" /><br>
+    Server: <input type="text" id="server" value="http://135.222.138.136:8888" /><br>
     Your name: <input type="text" id="local" value="myclient"/>
     <button id="connect" onclick="connect();">Connect</button>
     <button disabled="true" id="disconnect" onclick="disconnect();">Disconnect</button>

--- a/peerconnection/client/conductor.cc
+++ b/peerconnection/client/conductor.cc
@@ -30,9 +30,9 @@
 #include <utility>
 
 #include "talk/app/webrtc/videosourceinterface.h"
-#include "talk/base/common.h"
-#include "talk/base/json.h"
-#include "talk/base/logging.h"
+#include "webrtc/base/common.h"
+#include "webrtc/base/json.h"
+#include "webrtc/base/logging.h"
 #include "talk/examples/peerconnection/client/defaults.h"
 #include "talk/media/devices/devicemanager.h"
 
@@ -50,7 +50,7 @@ class DummySetSessionDescriptionObserver
  public:
   static DummySetSessionDescriptionObserver* Create() {
     return
-        new talk_base::RefCountedObject<DummySetSessionDescriptionObserver>();
+        new rtc::RefCountedObject<DummySetSessionDescriptionObserver>();
   }
   virtual void OnSuccess() {
     LOG(INFO) << __FUNCTION__;
@@ -109,6 +109,7 @@ bool Conductor::InitializePeerConnection() {
   servers.push_back(server);
   peer_connection_ = peer_connection_factory_->CreatePeerConnection(servers,
                                                                     &constraints_,
+                                                                    NULL,
                                                                     NULL,
                                                                     this);
   if (!peer_connection_.get()) {
@@ -277,7 +278,7 @@ void Conductor::OnMessageFromPeer(int peer_id, const std::string& message) {
       LOG(WARNING) << "Can't parse received message.";
       return;
     }
-    talk_base::scoped_ptr<webrtc::IceCandidateInterface> candidate(
+    rtc::scoped_ptr<webrtc::IceCandidateInterface> candidate(
         webrtc::CreateIceCandidate(sdp_mid, sdp_mlineindex, sdp));
     if (!candidate.get()) {
       LOG(WARNING) << "Can't parse received candidate message.";
@@ -336,7 +337,7 @@ void Conductor::ConnectToPeer(int peer_id) {
 }
 
 cricket::VideoCapturer* Conductor::OpenVideoCaptureDevice() {
-  talk_base::scoped_ptr<cricket::DeviceManagerInterface> dev_manager(
+  rtc::scoped_ptr<cricket::DeviceManagerInterface> dev_manager(
       cricket::DeviceManagerFactory::Create());
   if (!dev_manager->Init()) {
     LOG(LS_ERROR) << "Can't create device manager";
@@ -361,27 +362,27 @@ void Conductor::AddStreams() {
   if (active_streams_.find(kStreamLabel) != active_streams_.end())
     return;  // Already added.
 
-  talk_base::scoped_refptr<webrtc::AudioTrackInterface> audio_track(
+  rtc::scoped_refptr<webrtc::AudioTrackInterface> audio_track(
       peer_connection_factory_->CreateAudioTrack(
           kAudioLabel, peer_connection_factory_->CreateAudioSource(NULL)));
 
-  talk_base::scoped_refptr<webrtc::VideoTrackInterface> video_track(
+  rtc::scoped_refptr<webrtc::VideoTrackInterface> video_track(
       peer_connection_factory_->CreateVideoTrack(
           kVideoLabel,
           peer_connection_factory_->CreateVideoSource(OpenVideoCaptureDevice(),
                                                       NULL)));
   main_wnd_->StartLocalRenderer(video_track);
 
-  talk_base::scoped_refptr<webrtc::MediaStreamInterface> stream =
+  rtc::scoped_refptr<webrtc::MediaStreamInterface> stream =
       peer_connection_factory_->CreateLocalMediaStream(kStreamLabel);
 
   stream->AddTrack(audio_track);
   stream->AddTrack(video_track);
-  if (!peer_connection_->AddStream(stream, NULL)) {
+  if (!peer_connection_->AddStream(stream)) {
     LOG(LS_ERROR) << "Adding stream to PeerConnection failed";
   }
   typedef std::pair<std::string,
-                    talk_base::scoped_refptr<webrtc::MediaStreamInterface> >
+                    rtc::scoped_refptr<webrtc::MediaStreamInterface> >
       MediaStreamPair;
   active_streams_.insert(MediaStreamPair(stream->label(), stream));
   main_wnd_->SwitchToStreamingUI();

--- a/peerconnection/client/conductor.h
+++ b/peerconnection/client/conductor.h
@@ -40,7 +40,7 @@
 #include "talk/app/webrtc/peerconnectioninterface.h"
 #include "talk/app/webrtc/test/fakeconstraints.h"
 #include "talk/app/webrtc/test/fakedtlsidentityservice.h"
-#include "talk/base/scoped_ptr.h"
+#include "webrtc/base/scoped_ptr.h"
 
 namespace webrtc {
 class VideoCaptureModule;
@@ -87,6 +87,7 @@ class Conductor
       webrtc::PeerConnectionObserver::StateType state_changed) {}
   virtual void OnAddStream(webrtc::MediaStreamInterface* stream);
   virtual void OnRemoveStream(webrtc::MediaStreamInterface* stream);
+  virtual void OnDataChannel(webrtc::DataChannelInterface* channel) {}
   virtual void OnRenegotiationNeeded() {}
   virtual void OnIceChange() {}
   virtual void OnIceCandidate(const webrtc::IceCandidateInterface* candidate);
@@ -134,13 +135,13 @@ class Conductor
   int peer_id_;
   
   webrtc::FakeConstraints constraints_;
-  talk_base::scoped_refptr<webrtc::PeerConnectionInterface> peer_connection_;
-  talk_base::scoped_refptr<webrtc::PeerConnectionFactoryInterface>
+  rtc::scoped_refptr<webrtc::PeerConnectionInterface> peer_connection_;
+  rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface>
       peer_connection_factory_;
   PeerConnectionClient* client_;
   MainWindow* main_wnd_;
   std::deque<std::string*> pending_messages_;
-  std::map<std::string, talk_base::scoped_refptr<webrtc::MediaStreamInterface> >
+  std::map<std::string, rtc::scoped_refptr<webrtc::MediaStreamInterface> >
       active_streams_;
   std::string server_;
 };

--- a/peerconnection/client/defaults.cc
+++ b/peerconnection/client/defaults.cc
@@ -36,7 +36,7 @@
 #include <unistd.h>
 #endif
 
-#include "talk/base/common.h"
+#include "webrtc/base/common.h"
 
 const char kAudioLabel[] = "audio_label";
 const char kVideoLabel[] = "video_label";

--- a/peerconnection/client/defaults.h
+++ b/peerconnection/client/defaults.h
@@ -31,7 +31,7 @@
 
 #include <string>
 
-#include "talk/base/basictypes.h"
+#include "webrtc/base/basictypes.h"
 
 extern const char kAudioLabel[];
 extern const char kVideoLabel[];

--- a/peerconnection/client/flagdefs.h
+++ b/peerconnection/client/flagdefs.h
@@ -29,7 +29,7 @@
 #define TALK_EXAMPLES_PEERCONNECTION_CLIENT_FLAGDEFS_H_
 #pragma once
 
-#include "talk/base/flags.h"
+#include "webrtc/base/flags.h"
 
 extern const uint16 kDefaultServerPort;  // From defaults.[h|cc]
 

--- a/peerconnection/client/linux/main.cc
+++ b/peerconnection/client/linux/main.cc
@@ -32,11 +32,12 @@
 #include "talk/examples/peerconnection/client/linux/main_wnd.h"
 #include "talk/examples/peerconnection/client/peer_connection_client.h"
 
-#include "talk/base/thread.h"
+#include "webrtc/base/ssladapter.h"
+#include "webrtc/base/thread.h"
 
-class CustomSocketServer : public talk_base::PhysicalSocketServer {
+class CustomSocketServer : public rtc::PhysicalSocketServer {
  public:
-  CustomSocketServer(talk_base::Thread* thread, GtkMainWnd* wnd)
+  CustomSocketServer(rtc::Thread* thread, GtkMainWnd* wnd)
       : thread_(thread), wnd_(wnd), conductor_(NULL), client_(NULL) {}
   virtual ~CustomSocketServer() {}
 
@@ -57,12 +58,12 @@ class CustomSocketServer : public talk_base::PhysicalSocketServer {
         client_ != NULL && !client_->is_connected()) {
       thread_->Quit();
     }
-    return talk_base::PhysicalSocketServer::Wait(0/*cms == -1 ? 1 : cms*/,
+    return rtc::PhysicalSocketServer::Wait(0/*cms == -1 ? 1 : cms*/,
                                                  process_io);
   }
 
  protected:
-  talk_base::Thread* thread_;
+  rtc::Thread* thread_;
   GtkMainWnd* wnd_;
   Conductor* conductor_;
   PeerConnectionClient* client_;
@@ -73,9 +74,9 @@ int main(int argc, char* argv[]) {
   g_type_init();
   g_thread_init(NULL);
 
-  FlagList::SetFlagsFromCommandLine(&argc, argv, true);
+  rtc::FlagList::SetFlagsFromCommandLine(&argc, argv, true);
   if (FLAG_help) {
-    FlagList::Print(NULL, false);
+    rtc::FlagList::Print(NULL, false);
     return 0;
   }
 
@@ -89,15 +90,16 @@ int main(int argc, char* argv[]) {
   GtkMainWnd wnd(FLAG_server, FLAG_port, FLAG_autoconnect, FLAG_autocall);
   wnd.Create();
 
-  talk_base::AutoThread auto_thread;
-  talk_base::Thread* thread = talk_base::Thread::Current();
+  rtc::AutoThread auto_thread;
+  rtc::Thread* thread = rtc::Thread::Current();
   CustomSocketServer socket_server(thread, &wnd);
   thread->set_socketserver(&socket_server);
 
+  rtc::InitializeSSL();
   // Must be constructed after we set the socketserver.
   PeerConnectionClient client;
-  talk_base::scoped_refptr<Conductor> conductor(
-      new talk_base::RefCountedObject<Conductor>(&client, &wnd));
+  rtc::scoped_refptr<Conductor> conductor(
+      new rtc::RefCountedObject<Conductor>(&client, &wnd));
   socket_server.set_client(&client);
   socket_server.set_conductor(conductor);
 
@@ -111,7 +113,7 @@ int main(int argc, char* argv[]) {
   //while (gtk_events_pending()) {
   //  gtk_main_iteration();
   //}
-
+  rtc::CleanupSSL();
   return 0;
 }
 

--- a/peerconnection/client/linux/main_wnd.cc
+++ b/peerconnection/client/linux/main_wnd.cc
@@ -33,11 +33,11 @@
 #include <stddef.h>
 
 #include "talk/examples/peerconnection/client/defaults.h"
-#include "talk/base/common.h"
-#include "talk/base/logging.h"
-#include "talk/base/stringutils.h"
+#include "webrtc/base/common.h"
+#include "webrtc/base/logging.h"
+#include "webrtc/base/stringutils.h"
 
-using talk_base::sprintfn;
+using rtc::sprintfn;
 
 namespace {
 

--- a/peerconnection/client/linux/main_wnd.h
+++ b/peerconnection/client/linux/main_wnd.h
@@ -110,11 +110,11 @@ class GtkMainWnd : public MainWindow {
     }
 
    protected:
-    talk_base::scoped_ptr<uint8[]> image_;
+    rtc::scoped_ptr<uint8[]> image_;
     int width_;
     int height_;
     GtkMainWnd* main_wnd_;
-    talk_base::scoped_refptr<webrtc::VideoTrackInterface> rendered_track_;
+    rtc::scoped_refptr<webrtc::VideoTrackInterface> rendered_track_;
   };
 
  protected:
@@ -129,9 +129,9 @@ class GtkMainWnd : public MainWindow {
   std::string port_;
   bool autoconnect_;
   bool autocall_;
-  talk_base::scoped_ptr<VideoRenderer> local_renderer_;
-  talk_base::scoped_ptr<VideoRenderer> remote_renderer_;
-  talk_base::scoped_ptr<uint8> draw_buffer_;
+  rtc::scoped_ptr<VideoRenderer> local_renderer_;
+  rtc::scoped_ptr<VideoRenderer> remote_renderer_;
+  rtc::scoped_ptr<uint8> draw_buffer_;
   int draw_buffer_size_;
 };
 

--- a/peerconnection/client/main.cc
+++ b/peerconnection/client/main.cc
@@ -35,11 +35,11 @@
 
 int PASCAL wWinMain(HINSTANCE instance, HINSTANCE prev_instance,
                     wchar_t* cmd_line, int cmd_show) {
-  talk_base::EnsureWinsockInit();
-  talk_base::Win32Thread w32_thread;
-  talk_base::ThreadManager::Instance()->SetCurrentThread(&w32_thread);
+  rtc::EnsureWinsockInit();
+  rtc::Win32Thread w32_thread;
+  rtc::ThreadManager::Instance()->SetCurrentThread(&w32_thread);
 
-	if (!talk_base::InitializeSSL(NULL) || !talk_base::InitializeSSLThread()) { 
+	if (!rtc::InitializeSSL(NULL) || !rtc::InitializeSSLThread()) { 
 	   LOG(LS_ERROR) << "Failed to initialize SSL"; 
 	   ASSERT(0);
 	} 
@@ -51,8 +51,8 @@ int PASCAL wWinMain(HINSTANCE instance, HINSTANCE prev_instance,
   }
 
   PeerConnectionClient client;
-  talk_base::scoped_refptr<Conductor> conductor(
-        new talk_base::RefCountedObject<Conductor>(&client, &wnd));
+  rtc::scoped_refptr<Conductor> conductor(
+        new rtc::RefCountedObject<Conductor>(&client, &wnd));
 
   // Main loop.
   MSG msg;
@@ -74,5 +74,6 @@ int PASCAL wWinMain(HINSTANCE instance, HINSTANCE prev_instance,
     }
   }
 
+  rtc::CleanupSSL();
   return 0;
 }

--- a/peerconnection/client/main_wnd.h
+++ b/peerconnection/client/main_wnd.h
@@ -33,7 +33,7 @@
 #include <string>
 
 #include "talk/app/webrtc/mediastreaminterface.h"
-#include "talk/base/win32.h"
+#include "webrtc/base/win32.h"
 #include "talk/examples/peerconnection/client/peer_connection_client.h"
 #include "talk/media/base/mediachannel.h"
 #include "talk/media/base/videocommon.h"
@@ -147,9 +147,9 @@ class MainWnd : public MainWindow {
 
     HWND wnd_;
     BITMAPINFO bmi_;
-    talk_base::scoped_ptr<uint8[]> image_;
+    rtc::scoped_ptr<uint8[]> image_;
     CRITICAL_SECTION buffer_lock_;
-    talk_base::scoped_refptr<webrtc::VideoTrackInterface> rendered_track_;
+    rtc::scoped_refptr<webrtc::VideoTrackInterface> rendered_track_;
   };
 
   // A little helper class to make sure we always to proper locking and
@@ -192,8 +192,8 @@ class MainWnd : public MainWindow {
   void HandleTabbing();
 
  private:
-  talk_base::scoped_ptr<VideoRenderer> local_renderer_;
-  talk_base::scoped_ptr<VideoRenderer> remote_renderer_;
+  rtc::scoped_ptr<VideoRenderer> local_renderer_;
+  rtc::scoped_ptr<VideoRenderer> remote_renderer_;
   UI ui_;
   HWND wnd_;
   DWORD ui_thread_id_;

--- a/peerconnection/client/peer_connection_client.cc
+++ b/peerconnection/client/peer_connection_client.cc
@@ -28,16 +28,16 @@
 #include "talk/examples/peerconnection/client/peer_connection_client.h"
 
 #include "talk/examples/peerconnection/client/defaults.h"
-#include "talk/base/common.h"
-#include "talk/base/nethelpers.h"
-#include "talk/base/logging.h"
-#include "talk/base/stringutils.h"
+#include "webrtc/base/common.h"
+#include "webrtc/base/nethelpers.h"
+#include "webrtc/base/logging.h"
+#include "webrtc/base/stringutils.h"
 
 #ifdef WIN32
-#include "talk/base/win32socketserver.h"
+#include "webrtc/base/win32socketserver.h"
 #endif
 
-using talk_base::sprintfn;
+using rtc::sprintfn;
 
 namespace {
 
@@ -46,13 +46,13 @@ const char kByeMessage[] = "BYE";
 // Delay between server connection retries, in milliseconds
 const int kReconnectDelay = 2000;
 
-talk_base::AsyncSocket* CreateClientSocket(int family) {
+rtc::AsyncSocket* CreateClientSocket(int family) {
 #ifdef WIN32
-  talk_base::Win32Socket* sock = new talk_base::Win32Socket();
+  rtc::Win32Socket* sock = new rtc::Win32Socket();
   sock->CreateT(family, SOCK_STREAM);
   return sock;
 #elif defined(POSIX)
-  talk_base::Thread* thread = talk_base::Thread::Current();
+  rtc::Thread* thread = rtc::Thread::Current();
   ASSERT(thread != NULL);
   return thread->socketserver()->CreateAsyncSocket(family, SOCK_STREAM);
 #else
@@ -133,7 +133,7 @@ void PeerConnectionClient::Connect(const std::string& server, int port,
 
   if (server_address_.IsUnresolved()) {
     state_ = RESOLVING;
-    resolver_ = new talk_base::AsyncResolver();
+    resolver_ = new rtc::AsyncResolver();
     resolver_->SignalDone.connect(this, &PeerConnectionClient::OnResolveResult);
     resolver_->Start(server_address_);
   } else {
@@ -142,7 +142,7 @@ void PeerConnectionClient::Connect(const std::string& server, int port,
 }
 
 void PeerConnectionClient::OnResolveResult(
-    talk_base::AsyncResolverInterface* resolver) {
+    rtc::AsyncResolverInterface* resolver) {
   if (resolver_->GetError() != 0) {
     callback_->OnServerConnectionFailure();
     resolver_->Destroy(false);
@@ -176,7 +176,7 @@ bool PeerConnectionClient::SendToPeer(int peer_id, const std::string& message) {
     return false;
 
   ASSERT(is_connected());
-  ASSERT(control_socket_->GetState() == talk_base::Socket::CS_CLOSED);
+  ASSERT(control_socket_->GetState() == rtc::Socket::CS_CLOSED);
   if (!is_connected() || peer_id == -1)
     return false;
 
@@ -198,17 +198,17 @@ bool PeerConnectionClient::SendHangUp(int peer_id) {
 
 bool PeerConnectionClient::IsSendingMessage() {
   return state_ == CONNECTED &&
-         control_socket_->GetState() != talk_base::Socket::CS_CLOSED;
+         control_socket_->GetState() != rtc::Socket::CS_CLOSED;
 }
 
 bool PeerConnectionClient::SignOut() {
   if (state_ == NOT_CONNECTED || state_ == SIGNING_OUT)
     return true;
 
-  if (hanging_get_->GetState() != talk_base::Socket::CS_CLOSED)
+  if (hanging_get_->GetState() != rtc::Socket::CS_CLOSED)
     hanging_get_->Close();
 
-  if (control_socket_->GetState() == talk_base::Socket::CS_CLOSED) {
+  if (control_socket_->GetState() == rtc::Socket::CS_CLOSED) {
     state_ = SIGNING_OUT;
 
     if (my_id_ != -1) {
@@ -242,7 +242,7 @@ void PeerConnectionClient::Close() {
 }
 
 bool PeerConnectionClient::ConnectControlSocket() {
-  ASSERT(control_socket_->GetState() == talk_base::Socket::CS_CLOSED);
+  ASSERT(control_socket_->GetState() == rtc::Socket::CS_CLOSED);
   int err = control_socket_->Connect(server_address_);
   if (err == SOCKET_ERROR) {
     Close();
@@ -251,22 +251,22 @@ bool PeerConnectionClient::ConnectControlSocket() {
   return true;
 }
 
-void PeerConnectionClient::OnConnect(talk_base::AsyncSocket* socket) {
+void PeerConnectionClient::OnConnect(rtc::AsyncSocket* socket) {
   ASSERT(!onconnect_data_.empty());
   size_t sent = socket->Send(onconnect_data_.c_str(), onconnect_data_.length());
   ASSERT(sent == onconnect_data_.length());
-  UNUSED(sent);
+  RTC_UNUSED(sent);
   onconnect_data_.clear();
 }
 
-void PeerConnectionClient::OnHangingGetConnect(talk_base::AsyncSocket* socket) {
+void PeerConnectionClient::OnHangingGetConnect(rtc::AsyncSocket* socket) {
   char buffer[1024];
   sprintfn(buffer, sizeof(buffer),
            "GET /wait?peer_id=%i HTTP/1.0\r\n\r\n", my_id_);
   int len = static_cast<int>(strlen(buffer));
   int sent = socket->Send(buffer, len);
   ASSERT(sent == len);
-  UNUSED2(sent, len);
+  RTC_UNUSED2(sent, len);
 }
 
 void PeerConnectionClient::OnMessageFromPeer(int peer_id,
@@ -308,7 +308,7 @@ bool PeerConnectionClient::GetHeaderValue(const std::string& data, size_t eoh,
   return false;
 }
 
-bool PeerConnectionClient::ReadIntoBuffer(talk_base::AsyncSocket* socket,
+bool PeerConnectionClient::ReadIntoBuffer(rtc::AsyncSocket* socket,
                                           std::string* data,
                                           size_t* content_length) {
   char buffer[0xffff];
@@ -346,7 +346,7 @@ bool PeerConnectionClient::ReadIntoBuffer(talk_base::AsyncSocket* socket,
   return ret;
 }
 
-void PeerConnectionClient::OnRead(talk_base::AsyncSocket* socket) {
+void PeerConnectionClient::OnRead(rtc::AsyncSocket* socket) {
   size_t content_length = 0;
   if (ReadIntoBuffer(socket, &control_data_, &content_length)) {
     size_t peer_id = 0, eoh = 0;
@@ -390,14 +390,14 @@ void PeerConnectionClient::OnRead(talk_base::AsyncSocket* socket) {
     control_data_.clear();
 
     if (state_ == SIGNING_IN) {
-      ASSERT(hanging_get_->GetState() == talk_base::Socket::CS_CLOSED);
+      ASSERT(hanging_get_->GetState() == rtc::Socket::CS_CLOSED);
       state_ = CONNECTED;
       hanging_get_->Connect(server_address_);
     }
   }
 }
 
-void PeerConnectionClient::OnHangingGetRead(talk_base::AsyncSocket* socket) {
+void PeerConnectionClient::OnHangingGetRead(rtc::AsyncSocket* socket) {
   LOG(INFO) << __FUNCTION__;
   size_t content_length = 0;
   if (ReadIntoBuffer(socket, &notification_data_, &content_length)) {
@@ -434,7 +434,7 @@ void PeerConnectionClient::OnHangingGetRead(talk_base::AsyncSocket* socket) {
     notification_data_.clear();
   }
 
-  if (hanging_get_->GetState() == talk_base::Socket::CS_CLOSED &&
+  if (hanging_get_->GetState() == rtc::Socket::CS_CLOSED &&
       state_ == CONNECTED) {
     hanging_get_->Connect(server_address_);
   }
@@ -496,7 +496,7 @@ bool PeerConnectionClient::ParseServerResponse(const std::string& response,
   return true;
 }
 
-void PeerConnectionClient::OnClose(talk_base::AsyncSocket* socket, int err) {
+void PeerConnectionClient::OnClose(rtc::AsyncSocket* socket, int err) {
   LOG(INFO) << __FUNCTION__;
 
   socket->Close();
@@ -517,7 +517,7 @@ void PeerConnectionClient::OnClose(talk_base::AsyncSocket* socket, int err) {
   } else {
     if (socket == control_socket_.get()) {
       LOG(WARNING) << "Connection refused; retrying in 2 seconds";
-      talk_base::Thread::Current()->PostDelayed(kReconnectDelay, this, 0);
+      rtc::Thread::Current()->PostDelayed(kReconnectDelay, this, 0);
     } else {
       Close();
       callback_->OnDisconnected();
@@ -525,7 +525,7 @@ void PeerConnectionClient::OnClose(talk_base::AsyncSocket* socket, int err) {
   }
 }
 
-void PeerConnectionClient::OnMessage(talk_base::Message* msg) {
+void PeerConnectionClient::OnMessage(rtc::Message* msg) {
   // ignore msg; there is currently only one supported message ("retry")
   DoConnect();
 }

--- a/peerconnection/client/peer_connection_client.h
+++ b/peerconnection/client/peer_connection_client.h
@@ -32,11 +32,11 @@
 #include <map>
 #include <string>
 
-#include "talk/base/nethelpers.h"
-#include "talk/base/signalthread.h"
-#include "talk/base/sigslot.h"
-#include "talk/base/physicalsocketserver.h"
-#include "talk/base/scoped_ptr.h"
+#include "webrtc/base/nethelpers.h"
+#include "webrtc/base/signalthread.h"
+#include "webrtc/base/sigslot.h"
+#include "webrtc/base/physicalsocketserver.h"
+#include "webrtc/base/scoped_ptr.h"
 
 typedef std::map<int, std::string> Peers;
 
@@ -54,7 +54,7 @@ struct PeerConnectionClientObserver {
 };
 
 class PeerConnectionClient : public sigslot::has_slots<>,
-                             public talk_base::MessageHandler {
+                             public rtc::MessageHandler {
  public:
   enum State {
     NOT_CONNECTED,
@@ -84,15 +84,15 @@ class PeerConnectionClient : public sigslot::has_slots<>,
   bool SignOut();
 
   // implements the MessageHandler interface
-  void OnMessage(talk_base::Message* msg);
+  void OnMessage(rtc::Message* msg);
 
  protected:
   void DoConnect();
   void Close();
   void InitSocketSignals();
   bool ConnectControlSocket();
-  void OnConnect(talk_base::AsyncSocket* socket);
-  void OnHangingGetConnect(talk_base::AsyncSocket* socket);
+  void OnConnect(rtc::AsyncSocket* socket);
+  void OnHangingGetConnect(rtc::AsyncSocket* socket);
   void OnMessageFromPeer(int peer_id, const std::string& message);
 
   // Quick and dirty support for parsing HTTP header values.
@@ -103,12 +103,12 @@ class PeerConnectionClient : public sigslot::has_slots<>,
                       const char* header_pattern, std::string* value);
 
   // Returns true if the whole response has been read.
-  bool ReadIntoBuffer(talk_base::AsyncSocket* socket, std::string* data,
+  bool ReadIntoBuffer(rtc::AsyncSocket* socket, std::string* data,
                       size_t* content_length);
 
-  void OnRead(talk_base::AsyncSocket* socket);
+  void OnRead(rtc::AsyncSocket* socket);
 
-  void OnHangingGetRead(talk_base::AsyncSocket* socket);
+  void OnHangingGetRead(rtc::AsyncSocket* socket);
 
   // Parses a single line entry in the form "<name>,<id>,<connected>"
   bool ParseEntry(const std::string& entry, std::string* name, int* id,
@@ -119,15 +119,15 @@ class PeerConnectionClient : public sigslot::has_slots<>,
   bool ParseServerResponse(const std::string& response, size_t content_length,
                            size_t* peer_id, size_t* eoh);
 
-  void OnClose(talk_base::AsyncSocket* socket, int err);
+  void OnClose(rtc::AsyncSocket* socket, int err);
 
-  void OnResolveResult(talk_base::AsyncResolverInterface* resolver);
+  void OnResolveResult(rtc::AsyncResolverInterface* resolver);
 
   PeerConnectionClientObserver* callback_;
-  talk_base::SocketAddress server_address_;
-  talk_base::AsyncResolver* resolver_;
-  talk_base::scoped_ptr<talk_base::AsyncSocket> control_socket_;
-  talk_base::scoped_ptr<talk_base::AsyncSocket> hanging_get_;
+  rtc::SocketAddress server_address_;
+  rtc::AsyncResolver* resolver_;
+  rtc::scoped_ptr<rtc::AsyncSocket> control_socket_;
+  rtc::scoped_ptr<rtc::AsyncSocket> hanging_get_;
   std::string onconnect_data_;
   std::string control_data_;
   std::string notification_data_;

--- a/peerconnection/server/main.cc
+++ b/peerconnection/server/main.cc
@@ -31,10 +31,10 @@
 
 #include <vector>
 
-#include "talk/base/flags.h"
 #include "talk/examples/peerconnection/server/data_socket.h"
 #include "talk/examples/peerconnection/server/peer_channel.h"
 #include "talk/examples/peerconnection/server/utils.h"
+#include "webrtc/base/flags.h"
 
 DEFINE_bool(help, false, "Prints this message");
 DEFINE_int(port, 8888, "The port on which to listen.");
@@ -67,9 +67,9 @@ void HandleBrowserRequest(DataSocket* ds, bool* quit) {
 }
 
 int main(int argc, char** argv) {
-  FlagList::SetFlagsFromCommandLine(&argc, argv, true);
+  rtc::FlagList::SetFlagsFromCommandLine(&argc, argv, true);
   if (FLAG_help) {
-    FlagList::Print(NULL, false);
+    rtc::FlagList::Print(NULL, false);
     return 0;
   }
 


### PR DESCRIPTION
The changes here just update Kam's original code to be compatible with (apparent) changes to webrtc since the original posting of this code...
I've tested this with Firefox (35.0) and Chrome (Version 39.0.2171.99).
On Firefox I was successful accessing the native-to-browser-test.html page whether it was as a local file or through a server. On Chrome I found that the video only worked when I accessed the page through a server.